### PR TITLE
Fixed incorrect case of PSU_OAuth2security.yaml ref

### DIFF
--- a/apis/v0/swagger/security/index.yaml
+++ b/apis/v0/swagger/security/index.yaml
@@ -1,4 +1,4 @@
 PSUOAuth2Security:
-  $ref: ./PSU_OAuth2Security.yaml
+  $ref: ./PSU_OAuth2security.yaml
 TPPOAuth2Security:
-  $ref: ./TPP_OAuth2Security.yaml
+  $ref: ./TPP_OAuth2security.yaml

--- a/apis/v1.0/swagger/security/index.yaml
+++ b/apis/v1.0/swagger/security/index.yaml
@@ -1,4 +1,4 @@
 PSUOAuth2Security:
-  $ref: ./PSU_OAuth2Security.yaml
+  $ref: ./PSU_OAuth2security.yaml
 TPPOAuth2Security:
-  $ref: ./TPP_OAuth2Security.yaml
+  $ref: ./TPP_OAuth2security.yaml

--- a/apis/v1.1/swagger/security/index.yaml
+++ b/apis/v1.1/swagger/security/index.yaml
@@ -1,4 +1,4 @@
 PSUOAuth2Security:
-  $ref: ./PSU_OAuth2Security.yaml
+  $ref: ./PSU_OAuth2security.yaml
 TPPOAuth2Security:
-  $ref: ./TPP_OAuth2Security.yaml
+  $ref: ./TPP_OAuth2security.yaml


### PR DESCRIPTION
The mismatched case causes the system to fail on linux.