### PR TITLE
Remove allOf use from active definitions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ compiled/*
 node_modules/*
 .DS_Store
 .~lock*
-account-info-swagger-dereferenced.yaml
 
 # Logs
 logs
@@ -12,6 +11,7 @@ npm-debug.log*
 # Ignore generated yaml
 inputs/v*/accounts/definitions/*.yaml
 account-info-swagger-dereferenced.yaml
+account-info-swagger-with-allof.*
 
 # Runtime data
 pids

--- a/dist/v2.0-rc3/account-info-swagger.json
+++ b/dist/v2.0-rc3/account-info-swagger.json
@@ -2335,6 +2335,11 @@
       "allOf": [
         {
           "$ref": "#/definitions/OBAccount2"
+        },
+        {
+          "required": [
+            "Account"
+          ]
         }
       ]
     },
@@ -2449,6 +2454,11 @@
       "allOf": [
         {
           "$ref": "#/definitions/OBBeneficiary2"
+        },
+        {
+          "required": [
+            "CreditorAccount"
+          ]
         }
       ]
     },
@@ -3874,6 +3884,11 @@
       "allOf": [
         {
           "$ref": "#/definitions/OBScheduledPayment1"
+        },
+        {
+          "required": [
+            "CreditorAccount"
+          ]
         }
       ]
     },
@@ -4042,6 +4057,11 @@
       "allOf": [
         {
           "$ref": "#/definitions/OBStandingOrder2"
+        },
+        {
+          "required": [
+            "CreditorAccount"
+          ]
         }
       ]
     },

--- a/dist/v2.0-rc3/account-info-swagger.json
+++ b/dist/v2.0-rc3/account-info-swagger.json
@@ -2238,59 +2238,128 @@
       "additionalProperties": false
     },
     "OBAccount2": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBAccount2Basic"
+      "description": "Unambiguous identification of the account to which credit and debit entries are made.",
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
-          "properties": {
-            "Account": {
-              "items": {
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OBCashAccount2"
-                  },
-                  {
-                    "description": "Provides the details to identify an account."
-                  },
-                  {
-                    "properties": {
-                      "Identification": {
-                        "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
-                      },
-                      "Name": {
-                        "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
-                      },
-                      "SecondaryIdentification": {
-                        "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                      }
-                    }
-                  }
+        "Currency": {
+          "description": "Identification of the currency in which the account is held. \nUsage: Currency should only be used in case one and the same account number covers several currencies\nand the initiating party needs to identify which currency needs to be used for settlement on the account.",
+          "type": "string",
+          "pattern": "^[A-Z]{3,3}$"
+        },
+        "AccountType": {
+          "description": "Specifies the type of account (personal or business).",
+          "type": "string",
+          "enum": [
+            "Business",
+            "Personal"
+          ]
+        },
+        "AccountSubType": {
+          "description": "Specifies the sub type of account (product family group).",
+          "type": "string",
+          "enum": [
+            "ChargeCard",
+            "CreditCard",
+            "CurrentAccount",
+            "EMoney",
+            "Loan",
+            "Mortgage",
+            "PrePaidCard",
+            "Savings"
+          ]
+        },
+        "Description": {
+          "description": "Specifies the description of the account type.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "Nickname": {
+          "description": "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 70
+        },
+        "Account": {
+          "items": {
+            "type": "object",
+            "properties": {
+              "SchemeName": {
+                "description": "Name of the identification scheme, in a coded form as published in an external list.",
+                "type": "string",
+                "enum": [
+                  "IBAN",
+                  "PAN",
+                  "SortCodeAccountNumber"
                 ]
               },
-              "type": "array",
-              "description": "Provides the details to identify an account."
+              "Identification": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 34,
+                "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+              },
+              "Name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 70,
+                "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+              },
+              "SecondaryIdentification": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 34,
+                "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+              }
             },
-            "Servicer": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
-                },
-                {
-                  "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Unique and unambiguous identification of the servicing institution."
-                    }
-                  }
-                }
+            "required": [
+              "SchemeName",
+              "Identification"
+            ],
+            "additionalProperties": false,
+            "description": "Provides the details to identify an account."
+          },
+          "type": "array",
+          "description": "Provides the details to identify an account."
+        },
+        "Servicer": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
               ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35,
+              "description": "Unique and unambiguous identification of the servicing institution."
             }
-          }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account."
         }
-      ]
+      },
+      "required": [
+        "AccountId",
+        "Currency",
+        "AccountType",
+        "AccountSubType"
+      ],
+      "additionalProperties": false
     },
     "OBAccount2Basic": {
       "description": "Unambiguous identification of the account to which credit and debit entries are made.",
@@ -2393,41 +2462,165 @@
       "additionalProperties": false
     },
     "OBBeneficiary2": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBBeneficiary2Basic"
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
+        "BeneficiaryId": {
+          "description": "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "Reference": {
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "CreditorAgent": {
+          "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account.",
+          "type": "object",
           "properties": {
-            "CreditorAgent": {
-              "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification3"
-            },
-            "CreditorAccount": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBCashAccount1"
-                },
-                {
-                  "description": "Provides the details to identify the beneficiary account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
-                    },
-                    "Name": {
-                      "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
-                    },
-                    "SecondaryIdentification": {
-                      "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                    }
-                  }
-                }
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
               ]
+            },
+            "Identification": {
+              "description": "Unique and unambiguous identification of the servicing institution.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35
+            },
+            "Name": {
+              "description": "Name by which an agent is known and which is usually used to identify that agent.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 140
+            },
+            "PostalAddress": {
+              "description": "Information that locates and identifies a specific address, as defined by postal services.",
+              "type": "object",
+              "properties": {
+                "AddressType": {
+                  "description": "Identifies the nature of the postal address.",
+                  "type": "string",
+                  "enum": [
+                    "Business",
+                    "Correspondence",
+                    "DeliveryTo",
+                    "MailTo",
+                    "POBox",
+                    "Postal",
+                    "Residential",
+                    "Statement"
+                  ]
+                },
+                "Department": {
+                  "description": "Identification of a division of a large organisation or building.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 70
+                },
+                "SubDepartment": {
+                  "description": "Identification of a sub-division of a large organisation or building.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 70
+                },
+                "StreetName": {
+                  "description": "Name of a street or thoroughfare.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 70
+                },
+                "BuildingNumber": {
+                  "description": "Number that identifies the position of a building on a street.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 16
+                },
+                "PostCode": {
+                  "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 16
+                },
+                "TownName": {
+                  "description": "Name of a built-up area, with defined boundaries, and a local government.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 35
+                },
+                "CountrySubDivision": {
+                  "description": "Identifies a subdivision of a country such as state, region, county.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 35
+                },
+                "Country": {
+                  "description": "Nation with its own government.",
+                  "type": "string",
+                  "pattern": "^[A-Z]{2,2}$"
+                },
+                "AddressLine": {
+                  "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 70
+                }
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
+        },
+        "CreditorAccount": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "IBAN",
+                "SortCodeAccountNumber"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+            },
+            "Name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70,
+              "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+            },
+            "SecondaryIdentification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Provides the details to identify the beneficiary account."
         }
-      ]
+      },
+      "additionalProperties": false
     },
     "OBBeneficiary2Basic": {
       "type": "object",
@@ -2566,14 +2759,18 @@
       "type": "object",
       "properties": {
         "AccountId": {
-          "$ref": "#/definitions/AccountId"
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
         "Amount": {
           "description": "Amount of money of the cash balance.",
           "type": "object",
           "properties": {
             "Amount": {
-              "$ref": "#/definitions/Amount"
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
             "Currency": {
               "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
@@ -2588,17 +2785,28 @@
           "additionalProperties": false
         },
         "CreditDebitIndicator": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OBCreditDebitCode"
-            },
-            {
-              "description": "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
-            }
-          ]
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
         },
         "Type": {
-          "$ref": "#/definitions/OBBalanceType1Code"
+          "description": "Balance type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "PreviouslyClosedBooked"
+          ]
         },
         "DateTime": {
           "description": "Indicates the date (and time) of the balance.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
@@ -2607,7 +2815,49 @@
         },
         "CreditLine": {
           "items": {
-            "$ref": "#/definitions/OBCreditLine1"
+            "description": "Set of elements used to provide details on the credit line.",
+            "type": "object",
+            "properties": {
+              "Included": {
+                "description": "Indicates whether or not the credit line is included in the balance of the account.\nUsage: If not present, credit line is not included in the balance amount of the account.",
+                "type": "boolean"
+              },
+              "Amount": {
+                "description": "Amount of money of the credit line.",
+                "type": "object",
+                "properties": {
+                  "Amount": {
+                    "type": "string",
+                    "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+                  },
+                  "Currency": {
+                    "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                    "type": "string",
+                    "pattern": "^[A-Z]{3,3}$"
+                  }
+                },
+                "required": [
+                  "Amount",
+                  "Currency"
+                ],
+                "additionalProperties": false
+              },
+              "Type": {
+                "description": "Limit type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "Available",
+                  "Credit",
+                  "Emergency",
+                  "Pre-Agreed",
+                  "Temporary"
+                ]
+              }
+            },
+            "required": [
+              "Included"
+            ],
+            "additionalProperties": false
           },
           "type": "array",
           "description": "Set of elements used to provide details on the credit line."
@@ -3465,42 +3715,90 @@
       "additionalProperties": false
     },
     "OBReadDataResponse1": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBReadData1"
+      "type": "object",
+      "properties": {
+        "Permissions": {
+          "items": {
+            "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+            "type": "string",
+            "enum": [
+              "ReadAccountsBasic",
+              "ReadAccountsDetail",
+              "ReadBalances",
+              "ReadBeneficiariesBasic",
+              "ReadBeneficiariesDetail",
+              "ReadDirectDebits",
+              "ReadOffers",
+              "ReadPAN",
+              "ReadParty",
+              "ReadPartyPSU",
+              "ReadProducts",
+              "ReadScheduledPaymentsBasic",
+              "ReadScheduledPaymentsDetail",
+              "ReadStandingOrdersBasic",
+              "ReadStandingOrdersDetail",
+              "ReadStatementsBasic",
+              "ReadStatementsDetail",
+              "ReadTransactionsBasic",
+              "ReadTransactionsCredits",
+              "ReadTransactionsDebits",
+              "ReadTransactionsDetail"
+            ]
+          },
+          "type": "array",
+          "description": "Specifies the Open Banking account request types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP.",
+          "minItems": 1
         },
-        {
-          "properties": {
-            "AccountRequestId": {
-              "description": "Unique identification as assigned to identify the account request resource.",
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 128
-            },
-            "CreationDateTime": {
-              "description": "Date and time at which the resource was created.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
-              "type": "string",
-              "format": "date-time"
-            },
-            "Status": {
-              "$ref": "#/definitions/OBExternalRequestStatus1Code"
-            },
-            "StatusUpdateDateTime": {
-              "description": "Date and time at which the resource status was updated.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
-              "type": "string",
-              "format": "date-time"
-            }
-          }
+        "ExpirationDateTime": {
+          "description": "Specified date and time the permissions will expire.\nIf this is not populated, the permissions will be open ended.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
         },
-        {
-          "required": [
-            "AccountRequestId",
-            "CreationDateTime",
-            "Status",
-            "StatusUpdateDateTime"
+        "TransactionFromDateTime": {
+          "description": "Specified start date and time for the transaction query period.\nIf this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "TransactionToDateTime": {
+          "description": "Specified end date and time for the transaction query period.\nIf this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "AccountRequestId": {
+          "description": "Unique identification as assigned to identify the account request resource.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "CreationDateTime": {
+          "description": "Date and time at which the resource was created.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "Status": {
+          "description": "Specifies the status of the account request resource.",
+          "type": "string",
+          "enum": [
+            "Authorised",
+            "AwaitingAuthorisation",
+            "Rejected",
+            "Revoked"
           ]
+        },
+        "StatusUpdateDateTime": {
+          "description": "Date and time at which the resource status was updated.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
         }
-      ]
+      },
+      "required": [
+        "Permissions",
+        "AccountRequestId",
+        "CreationDateTime",
+        "Status",
+        "StatusUpdateDateTime"
+      ],
+      "additionalProperties": false
     },
     "OBReadDirectDebit1": {
       "type": "object",
@@ -3776,55 +4074,128 @@
       "additionalProperties": false
     },
     "OBScheduledPayment1": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBScheduledPayment1Basic"
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
+        "ScheduledPaymentId": {
+          "description": "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "ScheduledPaymentDateTime": {
+          "description": "The date on which the scheduled payment will be made.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ScheduledType": {
+          "description": "Specifies the scheduled payment date type requested",
+          "type": "string",
+          "enum": [
+            "Arrival",
+            "Execution"
+          ]
+        },
+        "InstructedAmount": {
+          "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain.",
+          "type": "object",
           "properties": {
-            "CreditorAgent": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
-                },
-                {
-                  "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Unique and unambiguous identification of the servicing institution."
-                    }
-                  }
-                }
+            "Amount": {
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+            },
+            "Currency": {
+              "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "Currency"
+          ],
+          "additionalProperties": false
+        },
+        "Reference": {
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "CreditorAgent": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
               ]
             },
-            "CreditorAccount": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBCashAccount1"
-                },
-                {
-                  "description": "Provides the details to identify the beneficiary account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Beneficiary account identification."
-                    },
-                    "Name": {
-                      "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
-                    },
-                    "SecondaryIdentification": {
-                      "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                    }
-                  }
-                }
-              ]
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35,
+              "description": "Unique and unambiguous identification of the servicing institution."
             }
-          }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+        },
+        "CreditorAccount": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "IBAN",
+                "SortCodeAccountNumber"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "Beneficiary account identification."
+            },
+            "Name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70,
+              "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+            },
+            "SecondaryIdentification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Provides the details to identify the beneficiary account."
         }
-      ]
+      },
+      "required": [
+        "AccountId",
+        "ScheduledPaymentDateTime",
+        "ScheduledType",
+        "InstructedAmount"
+      ],
+      "additionalProperties": false
     },
     "OBScheduledPayment1Basic": {
       "type": "object",
@@ -3893,55 +4264,186 @@
       ]
     },
     "OBStandingOrder2": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBStandingOrder2Basic"
+      "description": "Account to or from which a cash entry is made.",
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
+        "StandingOrderId": {
+          "description": "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "Frequency": {
+          "description": "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED)\nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35,
+          "pattern": "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+        },
+        "Reference": {
+          "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "FirstPaymentDateTime": {
+          "description": "The date on which the first payment for a Standing Order schedule will be made.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "FirstPaymentAmount": {
+          "description": "The amount of the first Standing Order",
+          "type": "object",
           "properties": {
-            "CreditorAgent": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBBranchAndFinancialInstitutionIdentification2"
-                },
-                {
-                  "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Unique and unambiguous identification of the servicing institution."
-                    }
-                  }
-                }
+            "Amount": {
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+            },
+            "Currency": {
+              "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "Currency"
+          ],
+          "additionalProperties": false
+        },
+        "NextPaymentDateTime": {
+          "description": "The date on which the next payment for a Standing Order schedule will be made.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "NextPaymentAmount": {
+          "description": "The amount of the next Standing Order",
+          "type": "object",
+          "properties": {
+            "Amount": {
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+            },
+            "Currency": {
+              "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "Currency"
+          ],
+          "additionalProperties": false
+        },
+        "FinalPaymentDateTime": {
+          "description": "The date on which the final payment for a Standing Order schedule will be made.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "FinalPaymentAmount": {
+          "description": "The amount of the final Standing Order",
+          "type": "object",
+          "properties": {
+            "Amount": {
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+            },
+            "Currency": {
+              "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "Currency"
+          ],
+          "additionalProperties": false
+        },
+        "StandingOrderStatusCode": {
+          "description": "Specifies the status of the standing order in code form.",
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
+        },
+        "CreditorAgent": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
               ]
             },
-            "CreditorAccount": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBCashAccount1"
-                },
-                {
-                  "description": "Provides the details to identify the beneficiary account."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Beneficiary account identification."
-                    },
-                    "Name": {
-                      "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
-                    },
-                    "SecondaryIdentification": {
-                      "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                    }
-                  }
-                }
-              ]
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35,
+              "description": "Unique and unambiguous identification of the servicing institution."
             }
-          }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+        },
+        "CreditorAccount": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "IBAN",
+                "SortCodeAccountNumber"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "Beneficiary account identification."
+            },
+            "Name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70,
+              "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+            },
+            "SecondaryIdentification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Provides the details to identify the beneficiary account."
         }
-      ]
+      },
+      "required": [
+        "AccountId",
+        "Frequency",
+        "NextPaymentDateTime",
+        "NextPaymentAmount"
+      ],
+      "additionalProperties": false
     },
     "OBStandingOrder2Basic": {
       "description": "Account to or from which a cash entry is made.",
@@ -4066,22 +4568,415 @@
       ]
     },
     "OBStatement1": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBStatement1Basic"
+      "description": "Provides further details on a statement resource.",
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
-          "properties": {
-            "StatementAmount": {
-              "items": {
-                "$ref": "#/definitions/OBStatementAmount1"
+        "StatementId": {
+          "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "StatementReference": {
+          "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "Type": {
+          "description": "Statement type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "AccountClosure",
+            "AccountOpening",
+            "Annual",
+            "Interim",
+            "RegularPeriodic"
+          ]
+        },
+        "StartDateTime": {
+          "description": "Date and time at which the statement period starts.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "EndDateTime": {
+          "description": "Date and time at which the statement period ends.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "CreationDateTime": {
+          "description": "Date and time at which the resource was created.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "StatementDescription": {
+          "items": {
+            "description": "Other descriptions that may be available for the statement resource.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          "type": "array",
+          "description": "Other descriptions that may be available for the statement resource."
+        },
+        "StatementBenefit": {
+          "items": {
+            "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource.",
+            "type": "object",
+            "properties": {
+              "Amount": {
+                "description": "Amount of money associated with the statement benefit type.",
+                "type": "object",
+                "properties": {
+                  "Amount": {
+                    "type": "string",
+                    "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+                  },
+                  "Currency": {
+                    "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                    "type": "string",
+                    "pattern": "^[A-Z]{3,3}$"
+                  }
+                },
+                "required": [
+                  "Amount",
+                  "Currency"
+                ],
+                "additionalProperties": false
               },
-              "type": "array",
-              "description": "Set of elements used to provide details of a generic amount for the statement resource."
-            }
-          }
+              "Type": {
+                "description": "Benefit type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "Cashback",
+                  "Insurance",
+                  "TravelDiscount",
+                  "TravelInsurance"
+                ]
+              }
+            },
+            "required": [
+              "Amount",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+        },
+        "StatementFee": {
+          "items": {
+            "description": "Set of elements used to provide details of a fee for the statement resource.",
+            "type": "object",
+            "properties": {
+              "Amount": {
+                "description": "Amount of money associated with the statement fee type.",
+                "type": "object",
+                "properties": {
+                  "Amount": {
+                    "type": "string",
+                    "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+                  },
+                  "Currency": {
+                    "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                    "type": "string",
+                    "pattern": "^[A-Z]{3,3}$"
+                  }
+                },
+                "required": [
+                  "Amount",
+                  "Currency"
+                ],
+                "additionalProperties": false
+              },
+              "CreditDebitIndicator": {
+                "type": "string",
+                "enum": [
+                  "Credit",
+                  "Debit"
+                ],
+                "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
+              },
+              "Type": {
+                "description": "Fee type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "Annual",
+                  "BalanceTransfer",
+                  "CashAdvance",
+                  "CashTransaction",
+                  "ForeignTransaction",
+                  "Gambling",
+                  "LatePayment",
+                  "MoneyTransfer",
+                  "Monthly",
+                  "Overlimit",
+                  "PostalOrder",
+                  "PrizeEntry",
+                  "StatementCopy",
+                  "Total"
+                ]
+              }
+            },
+            "required": [
+              "Amount",
+              "CreditDebitIndicator",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a fee for the statement resource."
+        },
+        "StatementInterest": {
+          "items": {
+            "description": "Set of elements used to provide details of a generic interest amount related to the statement resource.",
+            "type": "object",
+            "properties": {
+              "Amount": {
+                "description": "Amount of money associated with the statement interest amount type.",
+                "type": "object",
+                "properties": {
+                  "Amount": {
+                    "type": "string",
+                    "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+                  },
+                  "Currency": {
+                    "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                    "type": "string",
+                    "pattern": "^[A-Z]{3,3}$"
+                  }
+                },
+                "required": [
+                  "Amount",
+                  "Currency"
+                ],
+                "additionalProperties": false
+              },
+              "CreditDebitIndicator": {
+                "type": "string",
+                "enum": [
+                  "Credit",
+                  "Debit"
+                ],
+                "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
+              },
+              "Type": {
+                "description": "Interest amount type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "BalanceTransfer",
+                  "Cash",
+                  "EstimatedNext",
+                  "Purchase",
+                  "Total"
+                ]
+              }
+            },
+            "required": [
+              "Amount",
+              "CreditDebitIndicator",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic interest amount related to the statement resource."
+        },
+        "StatementDateTime": {
+          "items": {
+            "description": "Set of elements used to provide details of a generic date time for the statement resource.",
+            "type": "object",
+            "properties": {
+              "DateTime": {
+                "description": "Date and time associated with the date time type.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+                "type": "string",
+                "format": "date-time"
+              },
+              "Type": {
+                "description": "Date time type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "BalanceTransferPromoEnd",
+                  "DirectDebitDue",
+                  "LastPayment",
+                  "LastStatement",
+                  "NextStatement",
+                  "PaymentDue",
+                  "PurchasePromoEnd",
+                  "StatementAvailable"
+                ]
+              }
+            },
+            "required": [
+              "DateTime",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic date time for the statement resource."
+        },
+        "StatementRate": {
+          "items": {
+            "description": "Set of elements used to provide details of a generic rate related to the statement resource.",
+            "type": "object",
+            "properties": {
+              "Rate": {
+                "description": "Rate associated with the statement rate type.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 10,
+                "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+              },
+              "Type": {
+                "description": "Statement rate type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "AnnualBalanceTransfer",
+                  "AnnualBalanceTransferAfterPromo",
+                  "AnnualBalanceTransferPromo",
+                  "AnnualCash",
+                  "AnnualPurchase",
+                  "AnnualPurchaseAfterPromo",
+                  "AnnualPurchasePromo",
+                  "MonthlyBalanceTransfer",
+                  "MonthlyCash",
+                  "MonthlyPurchase"
+                ]
+              }
+            },
+            "required": [
+              "Rate",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic rate related to the statement resource."
+        },
+        "StatementValue": {
+          "items": {
+            "description": "Set of elements used to provide details of a generic number value related to the statement resource.",
+            "type": "object",
+            "properties": {
+              "Value": {
+                "description": "Value associated with the statement value type.",
+                "type": "integer",
+                "format": "int32"
+              },
+              "Type": {
+                "description": "Statement value type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "AirMilesPoints",
+                  "AirMilesPointsBalance",
+                  "Credits",
+                  "Debits",
+                  "HotelPoints",
+                  "HotelPointsBalance",
+                  "RetailShoppingPoints",
+                  "RetailShoppingPointsBalance"
+                ]
+              }
+            },
+            "required": [
+              "Value",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic number value related to the statement resource."
+        },
+        "StatementAmount": {
+          "items": {
+            "description": "Set of elements used to provide details of a generic amount for the statement resource.",
+            "type": "object",
+            "properties": {
+              "Amount": {
+                "description": "Amount of money associated with the amount type.",
+                "type": "object",
+                "properties": {
+                  "Amount": {
+                    "type": "string",
+                    "pattern": "^\\d{1,13}\\.\\d{1,5}$"
+                  },
+                  "Currency": {
+                    "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                    "type": "string",
+                    "pattern": "^[A-Z]{3,3}$"
+                  }
+                },
+                "required": [
+                  "Amount",
+                  "Currency"
+                ],
+                "additionalProperties": false
+              },
+              "CreditDebitIndicator": {
+                "type": "string",
+                "enum": [
+                  "Credit",
+                  "Debit"
+                ],
+                "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
+              },
+              "Type": {
+                "description": "Amount type, in a coded form.",
+                "type": "string",
+                "enum": [
+                  "ArrearsClosingBalance",
+                  "AvailableBalance",
+                  "AverageBalanceWhenInCredit",
+                  "AverageBalanceWhenInDebit",
+                  "AverageDailyBalance",
+                  "BalanceTransferClosingBalance",
+                  "CashClosingBalance",
+                  "ClosingBalance",
+                  "CreditLimit",
+                  "CurrentPayment",
+                  "DirectDebitPaymentDue",
+                  "FSCSInsurance",
+                  "MinimumPaymentDue",
+                  "PreviousClosingBalance",
+                  "PreviousPayment",
+                  "PurchaseClosingBalance",
+                  "StartingBalance",
+                  "TotalAdjustments",
+                  "TotalCashAdvances",
+                  "TotalCharges",
+                  "TotalCredits",
+                  "TotalDebits",
+                  "TotalPurchases"
+                ]
+              }
+            },
+            "required": [
+              "Amount",
+              "CreditDebitIndicator",
+              "Type"
+            ],
+            "additionalProperties": false
+          },
+          "type": "array",
+          "description": "Set of elements used to provide details of a generic amount for the statement resource."
         }
-      ]
+      },
+      "required": [
+        "AccountId",
+        "Type",
+        "StartDateTime",
+        "EndDateTime",
+        "CreationDateTime"
+      ],
+      "additionalProperties": false
     },
     "OBStatement1Basic": {
       "description": "Provides further details on a statement resource.",
@@ -4198,7 +5093,8 @@
           "type": "object",
           "properties": {
             "Amount": {
-              "$ref": "#/definitions/Amount"
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
             "Currency": {
               "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
@@ -4213,17 +5109,41 @@
           "additionalProperties": false
         },
         "CreditDebitIndicator": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OBCreditDebitCode"
-            },
-            {
-              "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
-            }
-          ]
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
         },
         "Type": {
-          "$ref": "#/definitions/OBExternalStatementAmountType1Code"
+          "description": "Amount type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "ArrearsClosingBalance",
+            "AvailableBalance",
+            "AverageBalanceWhenInCredit",
+            "AverageBalanceWhenInDebit",
+            "AverageDailyBalance",
+            "BalanceTransferClosingBalance",
+            "CashClosingBalance",
+            "ClosingBalance",
+            "CreditLimit",
+            "CurrentPayment",
+            "DirectDebitPaymentDue",
+            "FSCSInsurance",
+            "MinimumPaymentDue",
+            "PreviousClosingBalance",
+            "PreviousPayment",
+            "PurchaseClosingBalance",
+            "StartingBalance",
+            "TotalAdjustments",
+            "TotalCashAdvances",
+            "TotalCharges",
+            "TotalCredits",
+            "TotalDebits",
+            "TotalPurchases"
+          ]
         }
       },
       "required": [
@@ -4294,7 +5214,8 @@
           "type": "object",
           "properties": {
             "Amount": {
-              "$ref": "#/definitions/Amount"
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
             "Currency": {
               "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
@@ -4309,17 +5230,32 @@
           "additionalProperties": false
         },
         "CreditDebitIndicator": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OBCreditDebitCode"
-            },
-            {
-              "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
-            }
-          ]
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
         },
         "Type": {
-          "$ref": "#/definitions/OBExternalStatementFeeType1Code"
+          "description": "Fee type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "Annual",
+            "BalanceTransfer",
+            "CashAdvance",
+            "CashTransaction",
+            "ForeignTransaction",
+            "Gambling",
+            "LatePayment",
+            "MoneyTransfer",
+            "Monthly",
+            "Overlimit",
+            "PostalOrder",
+            "PrizeEntry",
+            "StatementCopy",
+            "Total"
+          ]
         }
       },
       "required": [
@@ -4338,7 +5274,8 @@
           "type": "object",
           "properties": {
             "Amount": {
-              "$ref": "#/definitions/Amount"
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
             "Currency": {
               "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
@@ -4353,17 +5290,23 @@
           "additionalProperties": false
         },
         "CreditDebitIndicator": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OBCreditDebitCode"
-            },
-            {
-              "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
-            }
-          ]
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
         },
         "Type": {
-          "$ref": "#/definitions/OBExternalStatementInterestType1Code"
+          "description": "Interest amount type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "BalanceTransfer",
+            "Cash",
+            "EstimatedNext",
+            "Purchase",
+            "Total"
+          ]
         }
       },
       "required": [
@@ -4414,70 +5357,422 @@
       "additionalProperties": false
     },
     "OBTransaction2": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/OBTransaction2Basic"
+      "description": "Provides further details on an entry in the report.",
+      "type": "object",
+      "properties": {
+        "AccountId": {
+          "description": "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
         },
-        {
+        "TransactionId": {
+          "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 40
+        },
+        "TransactionReference": {
+          "description": "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 35
+        },
+        "StatementReference": {
+          "items": {
+            "description": "Unique reference for the statement. This reference may be optionally populated if available.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 35
+          },
+          "type": "array",
+          "description": "Unique reference for the statement. This reference may be optionally populated if available."
+        },
+        "Amount": {
+          "description": "Amount of money in the cash transaction entry.",
+          "type": "object",
           "properties": {
-            "TransactionInformation": {
-              "$ref": "#/definitions/TransactionInformation"
+            "Amount": {
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
-            "Balance": {
-              "$ref": "#/definitions/OBTransactionCashBalance"
+            "Currency": {
+              "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "Currency"
+          ],
+          "additionalProperties": false
+        },
+        "CreditDebitIndicator": {
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the transaction is a credit or a debit entry."
+        },
+        "Status": {
+          "description": "Status of a transaction entry on the books of the account servicer.",
+          "type": "string",
+          "enum": [
+            "Booked",
+            "Pending"
+          ]
+        },
+        "BookingDateTime": {
+          "description": "Date and time when a transaction entry is posted to an account on the account servicer's books.\nUsage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "ValueDateTime": {
+          "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry.\nUsage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date.\nFor transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.\nAll dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
+          "type": "string",
+          "format": "date-time"
+        },
+        "AddressLine": {
+          "description": "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 70
+        },
+        "BankTransactionCode": {
+          "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry.",
+          "type": "object",
+          "properties": {
+            "Code": {
+              "description": "Specifies the family within a domain.",
+              "type": "string"
             },
-            "MerchantDetails": {
-              "$ref": "#/definitions/OBMerchantDetails1"
+            "SubCode": {
+              "description": "Specifies the sub-product family within a specific family.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "Code",
+            "SubCode"
+          ],
+          "additionalProperties": false
+        },
+        "ProprietaryBankTransactionCode": {
+          "description": "Set of elements to fully identify a proprietary bank transaction code.",
+          "type": "object",
+          "properties": {
+            "Code": {
+              "description": "Proprietary bank transaction code to identify the underlying transaction.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35
             },
-            "CreditorAccount": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBCashAccount2"
+            "Issuer": {
+              "description": "Identification of the issuer of the proprietary bank transaction code.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35
+            }
+          },
+          "required": [
+            "Code"
+          ],
+          "additionalProperties": false
+        },
+        "EquivalentAmount": {
+          "description": "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency. \nUsage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR).",
+          "type": "object",
+          "properties": {
+            "Amount": {
+              "description": "Amount of money to be transferred between debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred in a different currency. \nUsage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The first agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR).",
+              "type": "object",
+              "properties": {
+                "Amount": {
+                  "type": "string",
+                  "pattern": "^\\d{1,13}\\.\\d{1,5}$"
                 },
-                {
-                  "description": "Unambiguous identification of the account of the creditor, in the case of a debit transaction."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
-                    },
-                    "Name": {
-                      "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number.\nOB: No name validation is expected for confirmation of payee."
-                    },
-                    "SecondaryIdentification": {
-                      "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                    }
-                  }
+                "Currency": {
+                  "description": "Code allocated to a currency, by a maintenance agency, under an international identification scheme as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\". Valid currency codes are registered with the ISO 4217 Maintenance Agency, and consist of three contiguous letters.",
+                  "type": "string",
+                  "pattern": "^[A-Z]{3,3}$"
                 }
+              },
+              "required": [
+                "Amount",
+                "Currency"
+              ],
+              "additionalProperties": false
+            },
+            "CurrencyOfTransfer": {
+              "description": "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account.",
+              "type": "string",
+              "pattern": "^[A-Z]{3,3}$"
+            }
+          },
+          "required": [
+            "Amount",
+            "CurrencyOfTransfer"
+          ],
+          "additionalProperties": false
+        },
+        "CreditorAgent": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
               ]
             },
-            "DebtorAccount": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/OBCashAccount2"
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35,
+              "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Financial institution servicing an account for the creditor."
+        },
+        "DebtorAgent": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "BICFI"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 35,
+              "description": "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Financial institution servicing an account for the debtor."
+        },
+        "CardInstrument": {
+          "description": "Set of elements to describe the card instrument used in the transaction.",
+          "type": "object",
+          "properties": {
+            "CardSchemeName": {
+              "description": "Name of the card scheme.",
+              "type": "string",
+              "enum": [
+                "AmericanExpress",
+                "Diners",
+                "Discover",
+                "MasterCard",
+                "VISA"
+              ]
+            },
+            "AuthorisationType": {
+              "description": "The card authorisation type.",
+              "type": "string",
+              "enum": [
+                "Contactless",
+                "None",
+                "PIN"
+              ]
+            },
+            "Name": {
+              "description": "Name of the cardholder using the card instrument.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70
+            },
+            "Identification": {
+              "description": "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34
+            }
+          },
+          "required": [
+            "CardSchemeName"
+          ],
+          "additionalProperties": false
+        },
+        "TransactionInformation": {
+          "description": "Further details of the transaction. \nThis is the transaction narrative, which is unstructured text.",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "Balance": {
+          "description": "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account.",
+          "type": "object",
+          "properties": {
+            "Amount": {
+              "description": "Amount of money of the cash balance after a transaction entry is applied to the account..",
+              "type": "object",
+              "properties": {
+                "Amount": {
+                  "type": "string",
+                  "pattern": "^\\d{1,13}\\.\\d{1,5}$"
                 },
-                {
-                  "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
-                },
-                {
-                  "properties": {
-                    "Identification": {
-                      "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
-                    },
-                    "Name": {
-                      "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
-                    },
-                    "SecondaryIdentification": {
-                      "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
-                    }
-                  }
+                "Currency": {
+                  "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                  "type": "string",
+                  "pattern": "^[A-Z]{3,3}$"
                 }
+              },
+              "required": [
+                "Amount",
+                "Currency"
+              ],
+              "additionalProperties": false
+            },
+            "CreditDebitIndicator": {
+              "type": "string",
+              "enum": [
+                "Credit",
+                "Debit"
+              ],
+              "description": "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
+            },
+            "Type": {
+              "description": "Balance type, in a coded form.",
+              "type": "string",
+              "enum": [
+                "ClosingAvailable",
+                "ClosingBooked",
+                "Expected",
+                "ForwardAvailable",
+                "Information",
+                "InterimAvailable",
+                "InterimBooked",
+                "OpeningAvailable",
+                "OpeningBooked",
+                "PreviouslyClosedBooked"
               ]
             }
-          }
+          },
+          "required": [
+            "Amount",
+            "CreditDebitIndicator",
+            "Type"
+          ],
+          "additionalProperties": false
+        },
+        "MerchantDetails": {
+          "description": "Details of the merchant involved in the transaction.",
+          "type": "object",
+          "properties": {
+            "MerchantName": {
+              "description": "Name by which the merchant is known.",
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 350
+            },
+            "MerchantCategoryCode": {
+              "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.",
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 4
+            }
+          },
+          "additionalProperties": false
+        },
+        "CreditorAccount": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "IBAN",
+                "PAN",
+                "SortCodeAccountNumber"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+            },
+            "Name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70,
+              "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number.\nOB: No name validation is expected for confirmation of payee."
+            },
+            "SecondaryIdentification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Unambiguous identification of the account of the creditor, in the case of a debit transaction."
+        },
+        "DebtorAccount": {
+          "type": "object",
+          "properties": {
+            "SchemeName": {
+              "description": "Name of the identification scheme, in a coded form as published in an external list.",
+              "type": "string",
+              "enum": [
+                "IBAN",
+                "PAN",
+                "SortCodeAccountNumber"
+              ]
+            },
+            "Identification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+            },
+            "Name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 70,
+              "description": "Name of the account, as assigned by the account servicing institution, in agreement with the account owner in order to provide an additional means of identification of the account.\nUsage: The account name is different from the account owner name. The account name is used in certain user communities to provide a means of identifying the account, in addition to the account owner's identity and the account number."
+            },
+            "SecondaryIdentification": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 34,
+              "description": "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+            }
+          },
+          "required": [
+            "SchemeName",
+            "Identification"
+          ],
+          "additionalProperties": false,
+          "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
         }
-      ]
+      },
+      "required": [
+        "AccountId",
+        "Amount",
+        "CreditDebitIndicator",
+        "Status",
+        "BookingDateTime"
+      ],
+      "additionalProperties": false
     },
     "OBTransaction2Basic": {
       "description": "Provides further details on an entry in the report.",
@@ -4691,7 +5986,8 @@
           "type": "object",
           "properties": {
             "Amount": {
-              "$ref": "#/definitions/Amount"
+              "type": "string",
+              "pattern": "^\\d{1,13}\\.\\d{1,5}$"
             },
             "Currency": {
               "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
@@ -4706,17 +6002,28 @@
           "additionalProperties": false
         },
         "CreditDebitIndicator": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/OBCreditDebitCode"
-            },
-            {
-              "description": "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
-            }
-          ]
+          "type": "string",
+          "enum": [
+            "Credit",
+            "Debit"
+          ],
+          "description": "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
         },
         "Type": {
-          "$ref": "#/definitions/OBBalanceType1Code"
+          "description": "Balance type, in a coded form.",
+          "type": "string",
+          "enum": [
+            "ClosingAvailable",
+            "ClosingBooked",
+            "Expected",
+            "ForwardAvailable",
+            "Information",
+            "InterimAvailable",
+            "InterimBooked",
+            "OpeningAvailable",
+            "OpeningBooked",
+            "PreviouslyClosedBooked"
+          ]
         }
       },
       "required": [

--- a/dist/v2.0-rc3/account-info-swagger.yaml
+++ b/dist/v2.0-rc3/account-info-swagger.yaml
@@ -1461,6 +1461,8 @@ definitions:
   OBAccount2Detail:
     allOf:
       - $ref: '#/definitions/OBAccount2'
+      - required:
+          - Account
   OBAddressTypeCode:
     description: Identifies the nature of the postal address.
     type: string
@@ -1572,6 +1574,8 @@ definitions:
   OBBeneficiary2Detail:
     allOf:
       - $ref: '#/definitions/OBBeneficiary2'
+      - required:
+          - CreditorAccount
   OBBranchAndFinancialInstitutionIdentification2:
     type: object
     properties:
@@ -2863,6 +2867,8 @@ definitions:
   OBScheduledPayment1Detail:
     allOf:
       - $ref: '#/definitions/OBScheduledPayment1'
+      - required:
+          - CreditorAccount
   OBStandingOrder2:
     allOf:
       - $ref: '#/definitions/OBStandingOrder2Basic'
@@ -3107,6 +3113,8 @@ definitions:
   OBStandingOrder2Detail:
     allOf:
       - $ref: '#/definitions/OBStandingOrder2'
+      - required:
+          - CreditorAccount
   OBStatement1:
     allOf:
       - $ref: '#/definitions/OBStatement1Basic'

--- a/dist/v2.0-rc3/account-info-swagger.yaml
+++ b/dist/v2.0-rc3/account-info-swagger.yaml
@@ -1368,55 +1368,142 @@ definitions:
       - Currency
     additionalProperties: false
   OBAccount2:
-    allOf:
-      - $ref: '#/definitions/OBAccount2Basic'
-      - properties:
-          Account:
-            items:
-              allOf:
-                - $ref: '#/definitions/OBCashAccount2'
-                - description: Provides the details to identify an account.
-                - properties:
-                    Identification:
-                      description: >-
-                        Identification assigned by an institution to identify an
-                        account. This identification is known by the account
-                        owner.
-                    Name:
-                      description: >-
-                        Name of the account, as assigned by the account
-                        servicing institution, in agreement with the account
-                        owner in order to provide an additional means of
-                        identification of the account.
+    description: >-
+      Unambiguous identification of the account to which credit and debit
+      entries are made.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Currency:
+        description: >-
+          Identification of the currency in which the account is held. 
 
-                        Usage: The account name is different from the account
-                        owner name. The account name is used in certain user
-                        communities to provide a means of identifying the
-                        account, in addition to the account owner's identity and
-                        the account number.
-                    SecondaryIdentification:
-                      description: >-
-                        This is secondary identification of the account, as
-                        assigned by the account servicing institution. 
+          Usage: Currency should only be used in case one and the same account
+          number covers several currencies
 
-                        This can be used by building societies to additionally
-                        identify accounts with a roll number (in addition to a
-                        sort code and account number combination).
-            type: array
-            description: Provides the details to identify an account.
-          Servicer:
-            allOf:
-              - $ref: '#/definitions/OBBranchAndFinancialInstitutionIdentification2'
-              - description: >-
-                  Party that manages the account on behalf of the account owner,
-                  that is manages the registration and booking of entries on the
-                  account, calculates balances on the account and provides
-                  information about the account.
-              - properties:
-                  Identification:
-                    description: >-
-                      Unique and unambiguous identification of the servicing
-                      institution.
+          and the initiating party needs to identify which currency needs to be
+          used for settlement on the account.
+        type: string
+        pattern: '^[A-Z]{3,3}$'
+      AccountType:
+        description: Specifies the type of account (personal or business).
+        type: string
+        enum:
+          - Business
+          - Personal
+      AccountSubType:
+        description: Specifies the sub type of account (product family group).
+        type: string
+        enum:
+          - ChargeCard
+          - CreditCard
+          - CurrentAccount
+          - EMoney
+          - Loan
+          - Mortgage
+          - PrePaidCard
+          - Savings
+      Description:
+        description: Specifies the description of the account type.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Nickname:
+        description: >-
+          The nickname of the account, assigned by the account owner in order to
+          provide an additional means of identification of the account.
+        type: string
+        minLength: 1
+        maxLength: 70
+      Account:
+        items:
+          type: object
+          properties:
+            SchemeName:
+              description: >-
+                Name of the identification scheme, in a coded form as published
+                in an external list.
+              type: string
+              enum: &ref_7
+                - IBAN
+                - PAN
+                - SortCodeAccountNumber
+            Identification:
+              type: string
+              minLength: 1
+              maxLength: 34
+              description: >-
+                Identification assigned by an institution to identify an
+                account. This identification is known by the account owner.
+            Name:
+              type: string
+              minLength: 1
+              maxLength: 70
+              description: >-
+                Name of the account, as assigned by the account servicing
+                institution, in agreement with the account owner in order to
+                provide an additional means of identification of the account.
+
+                Usage: The account name is different from the account owner
+                name. The account name is used in certain user communities to
+                provide a means of identifying the account, in addition to the
+                account owner's identity and the account number.
+            SecondaryIdentification:
+              type: string
+              minLength: 1
+              maxLength: 34
+              description: >-
+                This is secondary identification of the account, as assigned by
+                the account servicing institution. 
+
+                This can be used by building societies to additionally identify
+                accounts with a roll number (in addition to a sort code and
+                account number combination).
+          required:
+            - SchemeName
+            - Identification
+          additionalProperties: false
+          description: Provides the details to identify an account.
+        type: array
+        description: Provides the details to identify an account.
+      Servicer:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: &ref_0
+              - BICFI
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+    required:
+      - AccountId
+      - Currency
+      - AccountType
+      - AccountSubType
+    additionalProperties: false
   OBAccount2Basic:
     description: >-
       Unambiguous identification of the account to which credit and debit
@@ -1506,41 +1593,194 @@ definitions:
       - SubCode
     additionalProperties: false
   OBBeneficiary2:
-    allOf:
-      - $ref: '#/definitions/OBBeneficiary2Basic'
-      - properties:
-          CreditorAgent:
-            $ref: '#/definitions/OBBranchAndFinancialInstitutionIdentification3'
-          CreditorAccount:
-            allOf:
-              - $ref: '#/definitions/OBCashAccount1'
-              - description: Provides the details to identify the beneficiary account.
-              - properties:
-                  Identification:
-                    description: >-
-                      Identification assigned by an institution to identify an
-                      account. This identification is known by the account
-                      owner.
-                  Name:
-                    description: >-
-                      Name of the account, as assigned by the account servicing
-                      institution, in agreement with the account owner in order
-                      to provide an additional means of identification of the
-                      account.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      BeneficiaryId:
+        description: >-
+          A unique and immutable identifier used to identify the beneficiary
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Reference:
+        description: >-
+          Unique reference, as assigned by the creditor, to unambiguously refer
+          to the payment transaction.
 
-                      Usage: The account name is different from the account
-                      owner name. The account name is used in certain user
-                      communities to provide a means of identifying the account,
-                      in addition to the account owner's identity and the
-                      account number.
-                  SecondaryIdentification:
-                    description: >-
-                      This is secondary identification of the account, as
-                      assigned by the account servicing institution. 
+          Usage: If available, the initiating party should provide this
+          reference in the structured remittance information, to enable
+          reconciliation by the creditor upon receipt of the amount of money.
 
-                      This can be used by building societies to additionally
-                      identify accounts with a roll number (in addition to a
-                      sort code and account number combination).
+          If the business context requires the use of a creditor reference or a
+          payment remit identification, and only one identifier can be passed
+          through the end-to-end chain, the creditor's reference or payment
+          remittance identification should be quoted in the end-to-end
+          transaction identification.
+        type: string
+        minLength: 1
+        maxLength: 35
+      CreditorAgent:
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_0
+          Identification:
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Name:
+            description: >-
+              Name by which an agent is known and which is usually used to
+              identify that agent.
+            type: string
+            minLength: 1
+            maxLength: 140
+          PostalAddress:
+            description: >-
+              Information that locates and identifies a specific address, as
+              defined by postal services.
+            type: object
+            properties:
+              AddressType:
+                description: Identifies the nature of the postal address.
+                type: string
+                enum:
+                  - Business
+                  - Correspondence
+                  - DeliveryTo
+                  - MailTo
+                  - POBox
+                  - Postal
+                  - Residential
+                  - Statement
+              Department:
+                description: >-
+                  Identification of a division of a large organisation or
+                  building.
+                type: string
+                minLength: 1
+                maxLength: 70
+              SubDepartment:
+                description: >-
+                  Identification of a sub-division of a large organisation or
+                  building.
+                type: string
+                minLength: 1
+                maxLength: 70
+              StreetName:
+                description: Name of a street or thoroughfare.
+                type: string
+                minLength: 1
+                maxLength: 70
+              BuildingNumber:
+                description: Number that identifies the position of a building on a street.
+                type: string
+                minLength: 1
+                maxLength: 16
+              PostCode:
+                description: >-
+                  Identifier consisting of a group of letters and/or numbers
+                  that is added to a postal address to assist the sorting of
+                  mail.
+                type: string
+                minLength: 1
+                maxLength: 16
+              TownName:
+                description: >-
+                  Name of a built-up area, with defined boundaries, and a local
+                  government.
+                type: string
+                minLength: 1
+                maxLength: 35
+              CountrySubDivision:
+                description: >-
+                  Identifies a subdivision of a country such as state, region,
+                  county.
+                type: string
+                minLength: 1
+                maxLength: 35
+              Country:
+                description: Nation with its own government.
+                type: string
+                pattern: '^[A-Z]{2,2}$'
+              AddressLine:
+                description: >-
+                  Information that locates and identifies a specific address, as
+                  defined by postal services, presented in free format text.
+                type: string
+                minLength: 1
+                maxLength: 70
+            additionalProperties: false
+        additionalProperties: false
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: &ref_2
+              - IBAN
+              - SortCodeAccountNumber
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              Identification assigned by an institution to identify an account.
+              This identification is known by the account owner.
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution. 
+
+              This can be used by building societies to additionally identify
+              accounts with a roll number (in addition to a sort code and
+              account number combination).
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    additionalProperties: false
   OBBeneficiary2Basic:
     type: object
     properties:
@@ -1662,13 +1902,19 @@ definitions:
     type: object
     properties:
       AccountId:
-        $ref: '#/definitions/AccountId'
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
       Amount:
         description: Amount of money of the cash balance.
         type: object
         properties:
-          Amount:
-            $ref: '#/definitions/Amount'
+          Amount: &ref_1
+            type: string
+            pattern: '^\d{1,13}\.\d{1,5}$'
           Currency:
             description: >-
               A code allocated to a currency by a Maintenance Agency under an
@@ -1682,13 +1928,27 @@ definitions:
           - Currency
         additionalProperties: false
       CreditDebitIndicator:
-        allOf:
-          - $ref: '#/definitions/OBCreditDebitCode'
-          - description: |-
-              Indicates whether the balance is a credit or a debit balance. 
-              Usage: A zero balance is considered to be a credit balance.
-      Type:
-        $ref: '#/definitions/OBBalanceType1Code'
+        type: string
+        enum:
+          - Credit
+          - Debit
+        description: |-
+          Indicates whether the balance is a credit or a debit balance. 
+          Usage: A zero balance is considered to be a credit balance.
+      Type: &ref_6
+        description: 'Balance type, in a coded form.'
+        type: string
+        enum:
+          - ClosingAvailable
+          - ClosingBooked
+          - Expected
+          - ForwardAvailable
+          - Information
+          - InterimAvailable
+          - InterimBooked
+          - OpeningAvailable
+          - OpeningBooked
+          - PreviouslyClosedBooked
       DateTime:
         description: >-
           Indicates the date (and time) of the balance.
@@ -1704,7 +1964,46 @@ definitions:
         format: date-time
       CreditLine:
         items:
-          $ref: '#/definitions/OBCreditLine1'
+          description: Set of elements used to provide details on the credit line.
+          type: object
+          properties:
+            Included:
+              description: >-
+                Indicates whether or not the credit line is included in the
+                balance of the account.
+
+                Usage: If not present, credit line is not included in the
+                balance amount of the account.
+              type: boolean
+            Amount:
+              description: Amount of money of the credit line.
+              type: object
+              properties:
+                Amount: *ref_1
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: '^[A-Z]{3,3}$'
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: 'Limit type, in a coded form.'
+              type: string
+              enum:
+                - Available
+                - Credit
+                - Emergency
+                - Pre-Agreed
+                - Temporary
+          required:
+            - Included
+          additionalProperties: false
         type: array
         description: Set of elements used to provide details on the credit line.
     required:
@@ -2511,49 +2810,138 @@ definitions:
       - Permissions
     additionalProperties: false
   OBReadDataResponse1:
-    allOf:
-      - $ref: '#/definitions/OBReadData1'
-      - properties:
-          AccountRequestId:
-            description: >-
-              Unique identification as assigned to identify the account request
-              resource.
-            type: string
-            minLength: 1
-            maxLength: 128
-          CreationDateTime:
-            description: >-
-              Date and time at which the resource was created.
+    type: object
+    properties:
+      Permissions:
+        items:
+          description: >-
+            Specifies the Open Banking account request types. This is a list of
+            the data clusters being consented by the PSU, and requested for
+            authorisation with the ASPSP.
+          type: string
+          enum:
+            - ReadAccountsBasic
+            - ReadAccountsDetail
+            - ReadBalances
+            - ReadBeneficiariesBasic
+            - ReadBeneficiariesDetail
+            - ReadDirectDebits
+            - ReadOffers
+            - ReadPAN
+            - ReadParty
+            - ReadPartyPSU
+            - ReadProducts
+            - ReadScheduledPaymentsBasic
+            - ReadScheduledPaymentsDetail
+            - ReadStandingOrdersBasic
+            - ReadStandingOrdersDetail
+            - ReadStatementsBasic
+            - ReadStatementsDetail
+            - ReadTransactionsBasic
+            - ReadTransactionsCredits
+            - ReadTransactionsDebits
+            - ReadTransactionsDetail
+        type: array
+        description: >-
+          Specifies the Open Banking account request types. This is a list of
+          the data clusters being consented by the PSU, and requested for
+          authorisation with the ASPSP.
+        minItems: 1
+      ExpirationDateTime:
+        description: >-
+          Specified date and time the permissions will expire.
 
-              All dates in the JSON payloads are represented in ISO 8601
-              date-time format. 
+          If this is not populated, the permissions will be open ended.
 
-              All date-time fields in responses must include the timezone. An
-              example is below:
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
 
-              2017-04-05T10:43:07+00:00
-            type: string
-            format: date-time
-          Status:
-            $ref: '#/definitions/OBExternalRequestStatus1Code'
-          StatusUpdateDateTime:
-            description: >-
-              Date and time at which the resource status was updated.
+          All date-time fields in responses must include the timezone. An
+          example is below:
 
-              All dates in the JSON payloads are represented in ISO 8601
-              date-time format. 
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      TransactionFromDateTime:
+        description: >-
+          Specified start date and time for the transaction query period.
 
-              All date-time fields in responses must include the timezone. An
-              example is below:
+          If this is not populated, the start date will be open ended, and data
+          will be returned from the earliest available transaction.
 
-              2017-04-05T10:43:07+00:00
-            type: string
-            format: date-time
-      - required:
-          - AccountRequestId
-          - CreationDateTime
-          - Status
-          - StatusUpdateDateTime
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      TransactionToDateTime:
+        description: >-
+          Specified end date and time for the transaction query period.
+
+          If this is not populated, the end date will be open ended, and data
+          will be returned to the latest available transaction.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      AccountRequestId:
+        description: >-
+          Unique identification as assigned to identify the account request
+          resource.
+        type: string
+        minLength: 1
+        maxLength: 128
+      CreationDateTime:
+        description: >-
+          Date and time at which the resource was created.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      Status:
+        description: Specifies the status of the account request resource.
+        type: string
+        enum:
+          - Authorised
+          - AwaitingAuthorisation
+          - Rejected
+          - Revoked
+      StatusUpdateDateTime:
+        description: >-
+          Date and time at which the resource status was updated.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+    required:
+      - Permissions
+      - AccountRequestId
+      - CreationDateTime
+      - Status
+      - StatusUpdateDateTime
+    additionalProperties: false
   OBReadDirectDebit1:
     type: object
     properties:
@@ -2745,51 +3133,157 @@ definitions:
       - Meta
     additionalProperties: false
   OBScheduledPayment1:
-    allOf:
-      - $ref: '#/definitions/OBScheduledPayment1Basic'
-      - properties:
-          CreditorAgent:
-            allOf:
-              - $ref: '#/definitions/OBBranchAndFinancialInstitutionIdentification2'
-              - description: >-
-                  Party that manages the account on behalf of the account owner,
-                  that is manages the registration and booking of entries on the
-                  account, calculates balances on the account and provides
-                  information about the account.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentId:
+        description: >-
+          A unique and immutable identifier used to identify the scheduled
+          payment resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      ScheduledPaymentDateTime:
+        description: >-
+          The date on which the scheduled payment will be made.
 
-                  This is the servicer of the beneficiary account.
-              - properties:
-                  Identification:
-                    description: >-
-                      Unique and unambiguous identification of the servicing
-                      institution.
-          CreditorAccount:
-            allOf:
-              - $ref: '#/definitions/OBCashAccount1'
-              - description: Provides the details to identify the beneficiary account.
-              - properties:
-                  Identification:
-                    description: Beneficiary account identification.
-                  Name:
-                    description: >-
-                      Name of the account, as assigned by the account servicing
-                      institution, in agreement with the account owner in order
-                      to provide an additional means of identification of the
-                      account.
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
 
-                      Usage: The account name is different from the account
-                      owner name. The account name is used in certain user
-                      communities to provide a means of identifying the account,
-                      in addition to the account owner's identity and the
-                      account number.
-                  SecondaryIdentification:
-                    description: >-
-                      This is secondary identification of the account, as
-                      assigned by the account servicing institution. 
+          All date-time fields in responses must include the timezone. An
+          example is below:
 
-                      This can be used by building societies to additionally
-                      identify accounts with a roll number (in addition to a
-                      sort code and account number combination).
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ScheduledType:
+        description: Specifies the scheduled payment date type requested
+        type: string
+        enum:
+          - Arrival
+          - Execution
+      InstructedAmount:
+        description: >-
+          Amount of money to be moved between the debtor and creditor, before
+          deduction of charges, expressed in the currency as ordered by the
+          initiating party.
+
+          Usage: This amount has to be transported unchanged through the
+          transaction chain.
+        type: object
+        properties:
+          Amount: *ref_1
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      Reference:
+        description: >-
+          Unique reference, as assigned by the creditor, to unambiguously refer
+          to the payment transaction.
+
+          Usage: If available, the initiating party should provide this
+          reference in the structured remittance information, to enable
+          reconciliation by the creditor upon receipt of the amount of money.
+
+          If the business context requires the use of a creditor reference or a
+          payment remit identification, and only one identifier can be passed
+          through the end-to-end chain, the creditor's reference or payment
+          remittance identification should be quoted in the end-to-end
+          transaction identification.
+        type: string
+        minLength: 1
+        maxLength: 35
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_0
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_2
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: Beneficiary account identification.
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution. 
+
+              This can be used by building societies to additionally identify
+              accounts with a roll number (in addition to a sort code and
+              account number combination).
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    required:
+      - AccountId
+      - ScheduledPaymentDateTime
+      - ScheduledType
+      - InstructedAmount
+    additionalProperties: false
   OBScheduledPayment1Basic:
     type: object
     properties:
@@ -2870,51 +3364,276 @@ definitions:
       - required:
           - CreditorAccount
   OBStandingOrder2:
-    allOf:
-      - $ref: '#/definitions/OBStandingOrder2Basic'
-      - properties:
-          CreditorAgent:
-            allOf:
-              - $ref: '#/definitions/OBBranchAndFinancialInstitutionIdentification2'
-              - description: >-
-                  Party that manages the account on behalf of the account owner,
-                  that is manages the registration and booking of entries on the
-                  account, calculates balances on the account and provides
-                  information about the account.
+    description: Account to or from which a cash entry is made.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StandingOrderId:
+        description: >-
+          A unique and immutable identifier used to identify the standing order
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      Frequency:
+        description: >-
+          Individual Definitions:
 
-                  This is the servicer of the beneficiary account.
-              - properties:
-                  Identification:
-                    description: >-
-                      Unique and unambiguous identification of the servicing
-                      institution.
-          CreditorAccount:
-            allOf:
-              - $ref: '#/definitions/OBCashAccount1'
-              - description: Provides the details to identify the beneficiary account.
-              - properties:
-                  Identification:
-                    description: Beneficiary account identification.
-                  Name:
-                    description: >-
-                      Name of the account, as assigned by the account servicing
-                      institution, in agreement with the account owner in order
-                      to provide an additional means of identification of the
-                      account.
+          EvryDay - Every day
 
-                      Usage: The account name is different from the account
-                      owner name. The account name is used in certain user
-                      communities to provide a means of identifying the account,
-                      in addition to the account owner's identity and the
-                      account number.
-                  SecondaryIdentification:
-                    description: >-
-                      This is secondary identification of the account, as
-                      assigned by the account servicing institution. 
+          EvryWorkgDay - Every working day
 
-                      This can be used by building societies to additionally
-                      identify accounts with a roll number (in addition to a
-                      sort code and account number combination).
+          IntrvlWkDay - An interval specified in weeks (01 to 09), and the day
+          within the week (01 to 07)
+
+          WkInMnthDay - A monthly interval, specifying the week of the month (01
+          to 05) and day within the week (01 to 07)
+
+          IntrvlMnthDay - An interval specified in months (between 01 to 06, 12,
+          24), specifying the day within the month (-5 to -1, 1 to 31)
+
+          QtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED)
+
+          Individual Patterns:
+
+          EvryDay (ScheduleCode)
+
+          EvryWorkgDay (ScheduleCode)
+
+          IntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks
+          + DayInWeek)
+
+          WkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth +
+          DayInWeek)
+
+          IntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode +
+          IntervalInMonths + DayInMonth)
+
+          QtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode +
+          QuarterDay
+
+          The regular expression for this element combines five smaller versions
+          for each permitted pattern. To aid legibility - the components are
+          presented individually here:
+
+          EvryDay
+
+          EvryWorkgDay
+
+          IntrvlWkDay:0[1-9]:0[1-7]
+
+          WkInMnthDay:0[1-5]:0[1-7]
+
+          IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])
+
+          QtrDay:(ENGLISH|SCOTTISH|RECEIVED)
+
+          Full Regular Expression:
+
+          ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
+        type: string
+        minLength: 1
+        maxLength: 35
+        pattern: >-
+          ^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$
+      Reference:
+        description: >-
+          Unique reference, as assigned by the creditor, to unambiguously refer
+          to the payment transaction.
+
+          Usage: If available, the initiating party should provide this
+          reference in the structured remittance information, to enable
+          reconciliation by the creditor upon receipt of the amount of money.
+
+          If the business context requires the use of a creditor reference or a
+          payment remit identification, and only one identifier can be passed
+          through the end-to-end chain, the creditor's reference or payment
+          remittance identification should be quoted in the end-to-end
+          transaction identification.
+        type: string
+        minLength: 1
+        maxLength: 35
+      FirstPaymentDateTime:
+        description: >-
+          The date on which the first payment for a Standing Order schedule will
+          be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FirstPaymentAmount:
+        description: The amount of the first Standing Order
+        type: object
+        properties:
+          Amount: *ref_1
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      NextPaymentDateTime:
+        description: >-
+          The date on which the next payment for a Standing Order schedule will
+          be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      NextPaymentAmount:
+        description: The amount of the next Standing Order
+        type: object
+        properties:
+          Amount: *ref_1
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      FinalPaymentDateTime:
+        description: >-
+          The date on which the final payment for a Standing Order schedule will
+          be made.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      FinalPaymentAmount:
+        description: The amount of the final Standing Order
+        type: object
+        properties:
+          Amount: *ref_1
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      StandingOrderStatusCode:
+        description: Specifies the status of the standing order in code form.
+        type: string
+        enum:
+          - Active
+          - Inactive
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_0
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of the servicing
+              institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Party that manages the account on behalf of the account owner, that is
+          manages the registration and booking of entries on the account,
+          calculates balances on the account and provides information about the
+          account.
+
+          This is the servicer of the beneficiary account.
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_2
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: Beneficiary account identification.
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution. 
+
+              This can be used by building societies to additionally identify
+              accounts with a roll number (in addition to a sort code and
+              account number combination).
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Provides the details to identify the beneficiary account.
+    required:
+      - AccountId
+      - Frequency
+      - NextPaymentDateTime
+      - NextPaymentAmount
+    additionalProperties: false
   OBStandingOrder2Basic:
     description: Account to or from which a cash entry is made.
     type: object
@@ -3116,16 +3835,418 @@ definitions:
       - required:
           - CreditorAccount
   OBStatement1:
-    allOf:
-      - $ref: '#/definitions/OBStatement1Basic'
-      - properties:
-          StatementAmount:
-            items:
-              $ref: '#/definitions/OBStatementAmount1'
-            type: array
-            description: >-
-              Set of elements used to provide details of a generic amount for
-              the statement resource.
+    description: Provides further details on a statement resource.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementId:
+        description: >-
+          Unique identifier for the statement resource within an servicing
+          institution. This identifier is both unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      StatementReference:
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+        type: string
+        minLength: 1
+        maxLength: 35
+      Type:
+        description: 'Statement type, in a coded form.'
+        type: string
+        enum:
+          - AccountClosure
+          - AccountOpening
+          - Annual
+          - Interim
+          - RegularPeriodic
+      StartDateTime:
+        description: >-
+          Date and time at which the statement period starts.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      EndDateTime:
+        description: >-
+          Date and time at which the statement period ends.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      CreationDateTime:
+        description: >-
+          Date and time at which the resource was created.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      StatementDescription:
+        items:
+          description: Other descriptions that may be available for the statement resource.
+          type: string
+          minLength: 1
+          maxLength: 500
+        type: array
+        description: Other descriptions that may be available for the statement resource.
+      StatementBenefit:
+        items:
+          description: >-
+            Set of elements used to provide details of a benefit or reward
+            amount for the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement benefit type.
+              type: object
+              properties:
+                Amount: *ref_1
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: '^[A-Z]{3,3}$'
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            Type:
+              description: 'Benefit type, in a coded form.'
+              type: string
+              enum:
+                - Cashback
+                - Insurance
+                - TravelDiscount
+                - TravelInsurance
+          required:
+            - Amount
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a benefit or reward amount
+          for the statement resource.
+      StatementFee:
+        items: &ref_4
+          description: >-
+            Set of elements used to provide details of a fee for the statement
+            resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the statement fee type.
+              type: object
+              properties:
+                Amount: *ref_1
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: '^[A-Z]{3,3}$'
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: |-
+                Indicates whether the amount is a credit or a debit. 
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: 'Fee type, in a coded form.'
+              type: string
+              enum:
+                - Annual
+                - BalanceTransfer
+                - CashAdvance
+                - CashTransaction
+                - ForeignTransaction
+                - Gambling
+                - LatePayment
+                - MoneyTransfer
+                - Monthly
+                - Overlimit
+                - PostalOrder
+                - PrizeEntry
+                - StatementCopy
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a fee for the statement
+          resource.
+      StatementInterest:
+        items: &ref_5
+          description: >-
+            Set of elements used to provide details of a generic interest amount
+            related to the statement resource.
+          type: object
+          properties:
+            Amount:
+              description: >-
+                Amount of money associated with the statement interest amount
+                type.
+              type: object
+              properties:
+                Amount: *ref_1
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: '^[A-Z]{3,3}$'
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: |-
+                Indicates whether the amount is a credit or a debit. 
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: 'Interest amount type, in a coded form.'
+              type: string
+              enum:
+                - BalanceTransfer
+                - Cash
+                - EstimatedNext
+                - Purchase
+                - Total
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic interest amount
+          related to the statement resource.
+      StatementDateTime:
+        items:
+          description: >-
+            Set of elements used to provide details of a generic date time for
+            the statement resource.
+          type: object
+          properties:
+            DateTime:
+              description: >-
+                Date and time associated with the date time type.
+
+                All dates in the JSON payloads are represented in ISO 8601
+                date-time format. 
+
+                All date-time fields in responses must include the timezone. An
+                example is below:
+
+                2017-04-05T10:43:07+00:00
+              type: string
+              format: date-time
+            Type:
+              description: 'Date time type, in a coded form.'
+              type: string
+              enum:
+                - BalanceTransferPromoEnd
+                - DirectDebitDue
+                - LastPayment
+                - LastStatement
+                - NextStatement
+                - PaymentDue
+                - PurchasePromoEnd
+                - StatementAvailable
+          required:
+            - DateTime
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic date time for the
+          statement resource.
+      StatementRate:
+        items:
+          description: >-
+            Set of elements used to provide details of a generic rate related to
+            the statement resource.
+          type: object
+          properties:
+            Rate:
+              description: Rate associated with the statement rate type.
+              type: string
+              minLength: 1
+              maxLength: 10
+              pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
+            Type:
+              description: 'Statement rate type, in a coded form.'
+              type: string
+              enum:
+                - AnnualBalanceTransfer
+                - AnnualBalanceTransferAfterPromo
+                - AnnualBalanceTransferPromo
+                - AnnualCash
+                - AnnualPurchase
+                - AnnualPurchaseAfterPromo
+                - AnnualPurchasePromo
+                - MonthlyBalanceTransfer
+                - MonthlyCash
+                - MonthlyPurchase
+          required:
+            - Rate
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic rate related to
+          the statement resource.
+      StatementValue:
+        items:
+          description: >-
+            Set of elements used to provide details of a generic number value
+            related to the statement resource.
+          type: object
+          properties:
+            Value:
+              description: Value associated with the statement value type.
+              type: integer
+              format: int32
+            Type:
+              description: 'Statement value type, in a coded form.'
+              type: string
+              enum:
+                - AirMilesPoints
+                - AirMilesPointsBalance
+                - Credits
+                - Debits
+                - HotelPoints
+                - HotelPointsBalance
+                - RetailShoppingPoints
+                - RetailShoppingPointsBalance
+          required:
+            - Value
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic number value
+          related to the statement resource.
+      StatementAmount:
+        items: &ref_3
+          description: >-
+            Set of elements used to provide details of a generic amount for the
+            statement resource.
+          type: object
+          properties:
+            Amount:
+              description: Amount of money associated with the amount type.
+              type: object
+              properties:
+                Amount: *ref_1
+                Currency:
+                  description: >-
+                    A code allocated to a currency by a Maintenance Agency under
+                    an international identification scheme, as described in the
+                    latest edition of the international standard ISO 4217 "Codes
+                    for the representation of currencies and funds".
+                  type: string
+                  pattern: '^[A-Z]{3,3}$'
+              required:
+                - Amount
+                - Currency
+              additionalProperties: false
+            CreditDebitIndicator:
+              type: string
+              enum:
+                - Credit
+                - Debit
+              description: |-
+                Indicates whether the amount is a credit or a debit. 
+                Usage: A zero amount is considered to be a credit amount.
+            Type:
+              description: 'Amount type, in a coded form.'
+              type: string
+              enum:
+                - ArrearsClosingBalance
+                - AvailableBalance
+                - AverageBalanceWhenInCredit
+                - AverageBalanceWhenInDebit
+                - AverageDailyBalance
+                - BalanceTransferClosingBalance
+                - CashClosingBalance
+                - ClosingBalance
+                - CreditLimit
+                - CurrentPayment
+                - DirectDebitPaymentDue
+                - FSCSInsurance
+                - MinimumPaymentDue
+                - PreviousClosingBalance
+                - PreviousPayment
+                - PurchaseClosingBalance
+                - StartingBalance
+                - TotalAdjustments
+                - TotalCashAdvances
+                - TotalCharges
+                - TotalCredits
+                - TotalDebits
+                - TotalPurchases
+          required:
+            - Amount
+            - CreditDebitIndicator
+            - Type
+          additionalProperties: false
+        type: array
+        description: >-
+          Set of elements used to provide details of a generic amount for the
+          statement resource.
+    required:
+      - AccountId
+      - Type
+      - StartDateTime
+      - EndDateTime
+      - CreationDateTime
+    additionalProperties: false
   OBStatement1Basic:
     description: Provides further details on a statement resource.
     type: object
@@ -3247,43 +4368,7 @@ definitions:
   OBStatement1Detail:
     allOf:
       - $ref: '#/definitions/OBStatement1'
-  OBStatementAmount1:
-    description: >-
-      Set of elements used to provide details of a generic amount for the
-      statement resource.
-    type: object
-    properties:
-      Amount:
-        description: Amount of money associated with the amount type.
-        type: object
-        properties:
-          Amount:
-            $ref: '#/definitions/Amount'
-          Currency:
-            description: >-
-              A code allocated to a currency by a Maintenance Agency under an
-              international identification scheme, as described in the latest
-              edition of the international standard ISO 4217 "Codes for the
-              representation of currencies and funds".
-            type: string
-            pattern: '^[A-Z]{3,3}$'
-        required:
-          - Amount
-          - Currency
-        additionalProperties: false
-      CreditDebitIndicator:
-        allOf:
-          - $ref: '#/definitions/OBCreditDebitCode'
-          - description: |-
-              Indicates whether the amount is a credit or a debit. 
-              Usage: A zero amount is considered to be a credit amount.
-      Type:
-        $ref: '#/definitions/OBExternalStatementAmountType1Code'
-    required:
-      - Amount
-      - CreditDebitIndicator
-      - Type
-    additionalProperties: false
+  OBStatementAmount1: *ref_3
   OBStatementBenefit1:
     description: >-
       Set of elements used to provide details of a benefit or reward amount for
@@ -3339,80 +4424,8 @@ definitions:
       - DateTime
       - Type
     additionalProperties: false
-  OBStatementFee1:
-    description: >-
-      Set of elements used to provide details of a fee for the statement
-      resource.
-    type: object
-    properties:
-      Amount:
-        description: Amount of money associated with the statement fee type.
-        type: object
-        properties:
-          Amount:
-            $ref: '#/definitions/Amount'
-          Currency:
-            description: >-
-              A code allocated to a currency by a Maintenance Agency under an
-              international identification scheme, as described in the latest
-              edition of the international standard ISO 4217 "Codes for the
-              representation of currencies and funds".
-            type: string
-            pattern: '^[A-Z]{3,3}$'
-        required:
-          - Amount
-          - Currency
-        additionalProperties: false
-      CreditDebitIndicator:
-        allOf:
-          - $ref: '#/definitions/OBCreditDebitCode'
-          - description: |-
-              Indicates whether the amount is a credit or a debit. 
-              Usage: A zero amount is considered to be a credit amount.
-      Type:
-        $ref: '#/definitions/OBExternalStatementFeeType1Code'
-    required:
-      - Amount
-      - CreditDebitIndicator
-      - Type
-    additionalProperties: false
-  OBStatementInterest1:
-    description: >-
-      Set of elements used to provide details of a generic interest amount
-      related to the statement resource.
-    type: object
-    properties:
-      Amount:
-        description: Amount of money associated with the statement interest amount type.
-        type: object
-        properties:
-          Amount:
-            $ref: '#/definitions/Amount'
-          Currency:
-            description: >-
-              A code allocated to a currency by a Maintenance Agency under an
-              international identification scheme, as described in the latest
-              edition of the international standard ISO 4217 "Codes for the
-              representation of currencies and funds".
-            type: string
-            pattern: '^[A-Z]{3,3}$'
-        required:
-          - Amount
-          - Currency
-        additionalProperties: false
-      CreditDebitIndicator:
-        allOf:
-          - $ref: '#/definitions/OBCreditDebitCode'
-          - description: |-
-              Indicates whether the amount is a credit or a debit. 
-              Usage: A zero amount is considered to be a credit amount.
-      Type:
-        $ref: '#/definitions/OBExternalStatementInterestType1Code'
-    required:
-      - Amount
-      - CreditDebitIndicator
-      - Type
-    additionalProperties: false
+  OBStatementFee1: *ref_4
+  OBStatementInterest1: *ref_5
   OBStatementRate1:
     description: >-
       Set of elements used to provide details of a generic rate related to the
@@ -3448,82 +4461,455 @@ definitions:
       - Type
     additionalProperties: false
   OBTransaction2:
-    allOf:
-      - $ref: '#/definitions/OBTransaction2Basic'
-      - properties:
-          TransactionInformation:
-            $ref: '#/definitions/TransactionInformation'
-          Balance:
-            $ref: '#/definitions/OBTransactionCashBalance'
-          MerchantDetails:
-            $ref: '#/definitions/OBMerchantDetails1'
-          CreditorAccount:
-            allOf:
-              - $ref: '#/definitions/OBCashAccount2'
-              - description: >-
-                  Unambiguous identification of the account of the creditor, in
-                  the case of a debit transaction.
-              - properties:
-                  Identification:
-                    description: >-
-                      Identification assigned by an institution to identify an
-                      account. This identification is known by the account
-                      owner.
-                  Name:
-                    description: >-
-                      Name of the account, as assigned by the account servicing
-                      institution, in agreement with the account owner in order
-                      to provide an additional means of identification of the
-                      account.
+    description: Provides further details on an entry in the report.
+    type: object
+    properties:
+      AccountId:
+        description: >-
+          A unique and immutable identifier used to identify the account
+          resource. This identifier has no meaning to the account owner.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionId:
+        description: >-
+          Unique identifier for the transaction within an servicing institution.
+          This identifier is both unique and immutable.
+        type: string
+        minLength: 1
+        maxLength: 40
+      TransactionReference:
+        description: >-
+          Unique reference for the transaction. This reference is optionally
+          populated, and may as an example be the FPID in the Faster Payments
+          context.
+        type: string
+        minLength: 1
+        maxLength: 35
+      StatementReference:
+        items:
+          description: >-
+            Unique reference for the statement. This reference may be optionally
+            populated if available.
+          type: string
+          minLength: 1
+          maxLength: 35
+        type: array
+        description: >-
+          Unique reference for the statement. This reference may be optionally
+          populated if available.
+      Amount:
+        description: Amount of money in the cash transaction entry.
+        type: object
+        properties:
+          Amount: *ref_1
+          Currency:
+            description: >-
+              A code allocated to a currency by a Maintenance Agency under an
+              international identification scheme, as described in the latest
+              edition of the international standard ISO 4217 "Codes for the
+              representation of currencies and funds".
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - Currency
+        additionalProperties: false
+      CreditDebitIndicator:
+        type: string
+        enum:
+          - Credit
+          - Debit
+        description: Indicates whether the transaction is a credit or a debit entry.
+      Status:
+        description: Status of a transaction entry on the books of the account servicer.
+        type: string
+        enum:
+          - Booked
+          - Pending
+      BookingDateTime:
+        description: >-
+          Date and time when a transaction entry is posted to an account on the
+          account servicer's books.
 
-                      Usage: The account name is different from the account
-                      owner name. The account name is used in certain user
-                      communities to provide a means of identifying the account,
-                      in addition to the account owner's identity and the
-                      account number.
+          Usage: Booking date is the expected booking date, unless the status is
+          booked, in which case it is the actual booking date.
 
-                      OB: No name validation is expected for confirmation of
-                      payee.
-                  SecondaryIdentification:
-                    description: >-
-                      This is secondary identification of the account, as
-                      assigned by the account servicing institution. 
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
 
-                      This can be used by building societies to additionally
-                      identify accounts with a roll number (in addition to a
-                      sort code and account number combination).
-          DebtorAccount:
-            allOf:
-              - $ref: '#/definitions/OBCashAccount2'
-              - description: >-
-                  Unambiguous identification of the account of the debtor, in
-                  the case of a crebit transaction.
-              - properties:
-                  Identification:
-                    description: >-
-                      Identification assigned by an institution to identify an
-                      account. This identification is known by the account
-                      owner.
-                  Name:
-                    description: >-
-                      Name of the account, as assigned by the account servicing
-                      institution, in agreement with the account owner in order
-                      to provide an additional means of identification of the
-                      account.
+          All date-time fields in responses must include the timezone. An
+          example is below:
 
-                      Usage: The account name is different from the account
-                      owner name. The account name is used in certain user
-                      communities to provide a means of identifying the account,
-                      in addition to the account owner's identity and the
-                      account number.
-                  SecondaryIdentification:
-                    description: >-
-                      This is secondary identification of the account, as
-                      assigned by the account servicing institution. 
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      ValueDateTime:
+        description: >-
+          Date and time at which assets become available to the account owner in
+          case of a credit entry, or cease to be available to the account owner
+          in case of a debit transaction entry.
 
-                      This can be used by building societies to additionally
-                      identify accounts with a roll number (in addition to a
-                      sort code and account number combination).
+          Usage: If transaction entry status is pending and value date is
+          present, then the value date refers to an expected/requested value
+          date.
+
+          For transaction entries subject to availability/float and for which
+          availability information is provided, the value date must not be used.
+          In this case the availability component identifies the number of
+          availability days.
+
+          All dates in the JSON payloads are represented in ISO 8601 date-time
+          format. 
+
+          All date-time fields in responses must include the timezone. An
+          example is below:
+
+          2017-04-05T10:43:07+00:00
+        type: string
+        format: date-time
+      AddressLine:
+        description: >-
+          Information that locates and identifies a specific address for a
+          transaction entry, that is presented in free format text.
+        type: string
+        minLength: 1
+        maxLength: 70
+      BankTransactionCode:
+        description: >-
+          Set of elements used to fully identify the type of underlying
+          transaction resulting in an entry.
+        type: object
+        properties:
+          Code:
+            description: Specifies the family within a domain.
+            type: string
+          SubCode:
+            description: Specifies the sub-product family within a specific family.
+            type: string
+        required:
+          - Code
+          - SubCode
+        additionalProperties: false
+      ProprietaryBankTransactionCode:
+        description: Set of elements to fully identify a proprietary bank transaction code.
+        type: object
+        properties:
+          Code:
+            description: >-
+              Proprietary bank transaction code to identify the underlying
+              transaction.
+            type: string
+            minLength: 1
+            maxLength: 35
+          Issuer:
+            description: >-
+              Identification of the issuer of the proprietary bank transaction
+              code.
+            type: string
+            minLength: 1
+            maxLength: 35
+        required:
+          - Code
+        additionalProperties: false
+      EquivalentAmount:
+        description: >-
+          Amount of money to be transferred between the debtor and creditor,
+          before deduction of charges, expressed in the currency of the debtor's
+          account, and to be transferred into a different currency. 
+
+          Usage : Currency of the amount is expressed in the currency of the
+          debtor's account, but the amount to be transferred is in another
+          currency. The debtor agent will convert the amount and currency to the
+          to be transferred amount and currency, eg, 'pay equivalent of 100000
+          EUR in JPY'(and account is in EUR).
+        type: object
+        properties:
+          Amount:
+            description: >-
+              Amount of money to be transferred between debtor and creditor,
+              before deduction of charges, expressed in the currency of the
+              debtor's account, and to be transferred in a different currency. 
+
+              Usage : Currency of the amount is expressed in the currency of the
+              debtor's account, but the amount to be transferred is in another
+              currency. The first agent will convert the amount and currency to
+              the to be transferred amount and currency, eg, 'pay equivalent of
+              100000 EUR in JPY'(and account is in EUR).
+            type: object
+            properties:
+              Amount: *ref_1
+              Currency:
+                description: >-
+                  Code allocated to a currency, by a maintenance agency, under
+                  an international identification scheme as described in the
+                  latest edition of the international standard ISO 4217 "Codes
+                  for the representation of currencies and funds". Valid
+                  currency codes are registered with the ISO 4217 Maintenance
+                  Agency, and consist of three contiguous letters.
+                type: string
+                pattern: '^[A-Z]{3,3}$'
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+          CurrencyOfTransfer:
+            description: >-
+              Specifies the currency of the to be transferred amount, which is
+              different from the currency of the debtor's account.
+            type: string
+            pattern: '^[A-Z]{3,3}$'
+        required:
+          - Amount
+          - CurrencyOfTransfer
+        additionalProperties: false
+      CreditorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_0
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the creditor.
+      DebtorAgent:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_0
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 35
+            description: >-
+              Unique and unambiguous identification of a financial institution
+              or a branch of a financial institution.
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: Financial institution servicing an account for the debtor.
+      CardInstrument:
+        description: >-
+          Set of elements to describe the card instrument used in the
+          transaction.
+        type: object
+        properties:
+          CardSchemeName:
+            description: Name of the card scheme.
+            type: string
+            enum:
+              - AmericanExpress
+              - Diners
+              - Discover
+              - MasterCard
+              - VISA
+          AuthorisationType:
+            description: The card authorisation type.
+            type: string
+            enum:
+              - Contactless
+              - None
+              - PIN
+          Name:
+            description: Name of the cardholder using the card instrument.
+            type: string
+            minLength: 1
+            maxLength: 70
+          Identification:
+            description: >-
+              Identification assigned by an institution to identify the card
+              instrument used in the transaction. This identification is known
+              by the account owner, and may be masked.
+            type: string
+            minLength: 1
+            maxLength: 34
+        required:
+          - CardSchemeName
+        additionalProperties: false
+      TransactionInformation:
+        description: |-
+          Further details of the transaction. 
+          This is the transaction narrative, which is unstructured text.
+        type: string
+        minLength: 1
+        maxLength: 500
+      Balance:
+        description: >-
+          Set of elements used to define the balance as a numerical
+          representation of the net increases and decreases in an account after
+          a transaction entry is applied to the account.
+        type: object
+        properties: &ref_8
+          Amount:
+            description: >-
+              Amount of money of the cash balance after a transaction entry is
+              applied to the account..
+            type: object
+            properties:
+              Amount: *ref_1
+              Currency:
+                description: >-
+                  A code allocated to a currency by a Maintenance Agency under
+                  an international identification scheme, as described in the
+                  latest edition of the international standard ISO 4217 "Codes
+                  for the representation of currencies and funds".
+                type: string
+                pattern: '^[A-Z]{3,3}$'
+            required:
+              - Amount
+              - Currency
+            additionalProperties: false
+          CreditDebitIndicator:
+            type: string
+            enum:
+              - Credit
+              - Debit
+            description: |-
+              Indicates whether the balance is a credit or a debit balance. 
+              Usage: A zero balance is considered to be a credit balance.
+          Type: *ref_6
+        required: &ref_9
+          - Amount
+          - CreditDebitIndicator
+          - Type
+        additionalProperties: false
+      MerchantDetails:
+        description: Details of the merchant involved in the transaction.
+        type: object
+        properties:
+          MerchantName:
+            description: Name by which the merchant is known.
+            type: string
+            minLength: 1
+            maxLength: 350
+          MerchantCategoryCode:
+            description: >-
+              Category code conform to ISO 18245, related to the type of
+              services or goods the merchant provides for the transaction.
+            type: string
+            minLength: 3
+            maxLength: 4
+        additionalProperties: false
+      CreditorAccount:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_7
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              Identification assigned by an institution to identify an account.
+              This identification is known by the account owner.
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+
+              OB: No name validation is expected for confirmation of payee.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution. 
+
+              This can be used by building societies to additionally identify
+              accounts with a roll number (in addition to a sort code and
+              account number combination).
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the creditor, in the case
+          of a debit transaction.
+      DebtorAccount:
+        type: object
+        properties:
+          SchemeName:
+            description: >-
+              Name of the identification scheme, in a coded form as published in
+              an external list.
+            type: string
+            enum: *ref_7
+          Identification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              Identification assigned by an institution to identify an account.
+              This identification is known by the account owner.
+          Name:
+            type: string
+            minLength: 1
+            maxLength: 70
+            description: >-
+              Name of the account, as assigned by the account servicing
+              institution, in agreement with the account owner in order to
+              provide an additional means of identification of the account.
+
+              Usage: The account name is different from the account owner name.
+              The account name is used in certain user communities to provide a
+              means of identifying the account, in addition to the account
+              owner's identity and the account number.
+          SecondaryIdentification:
+            type: string
+            minLength: 1
+            maxLength: 34
+            description: >-
+              This is secondary identification of the account, as assigned by
+              the account servicing institution. 
+
+              This can be used by building societies to additionally identify
+              accounts with a roll number (in addition to a sort code and
+              account number combination).
+        required:
+          - SchemeName
+          - Identification
+        additionalProperties: false
+        description: >-
+          Unambiguous identification of the account of the debtor, in the case
+          of a crebit transaction.
+    required:
+      - AccountId
+      - Amount
+      - CreditDebitIndicator
+      - Status
+      - BookingDateTime
+    additionalProperties: false
   OBTransaction2Basic:
     description: Provides further details on an entry in the report.
     type: object
@@ -3737,39 +5123,8 @@ definitions:
       of the net increases and decreases in an account after a transaction entry
       is applied to the account.
     type: object
-    properties:
-      Amount:
-        description: >-
-          Amount of money of the cash balance after a transaction entry is
-          applied to the account..
-        type: object
-        properties:
-          Amount:
-            $ref: '#/definitions/Amount'
-          Currency:
-            description: >-
-              A code allocated to a currency by a Maintenance Agency under an
-              international identification scheme, as described in the latest
-              edition of the international standard ISO 4217 "Codes for the
-              representation of currencies and funds".
-            type: string
-            pattern: '^[A-Z]{3,3}$'
-        required:
-          - Amount
-          - Currency
-        additionalProperties: false
-      CreditDebitIndicator:
-        allOf:
-          - $ref: '#/definitions/OBCreditDebitCode'
-          - description: |-
-              Indicates whether the balance is a credit or a debit balance. 
-              Usage: A zero balance is considered to be a credit balance.
-      Type:
-        $ref: '#/definitions/OBBalanceType1Code'
-    required:
-      - Amount
-      - CreditDebitIndicator
-      - Type
+    properties: *ref_8
+    required: *ref_9
     additionalProperties: false
   OB_OtherProductType1:
     description: >-

--- a/inputs/csv-to-yaml.js
+++ b/inputs/csv-to-yaml.js
@@ -297,11 +297,13 @@ const detailPermissionProperties = (permissions, property, properties) => {
   return detailProperties;
 };
 
-const mandatoryForKey = (key) => {
-  if (key === 'OBAccount1') {
-    return ['Account'];
-  }
-  return [];
+const mandatoryProperties = (detailProperties, permissions) => {
+  const requiredXpaths = permissions
+    .filter(p => p.Occurrence.startsWith('1..'))
+    .map(p => p.XPath);
+  return detailProperties
+    .filter(p => requiredXpaths.includes(p.XPath))
+    .map(p => p.Name);
 };
 
 const extendBasicPropertiesObj = (key, detailProperties, separateDefinitions, isoDescription, rows) => ({ // eslint-disable-line
@@ -314,8 +316,8 @@ const extendBasicPropertiesObj = (key, detailProperties, separateDefinitions, is
   ],
 });
 
-const makeDetailSchema = (key) => {
-  const required = mandatoryForKey(key);
+const makeDetailSchema = (key, detailProperties, permissions) => {
+  const required = mandatoryProperties(detailProperties, permissions);
   const label = `${key}Detail`;
   const detail = {
     [label]: {
@@ -408,7 +410,7 @@ const makeSchema = (
     delete obj[key].description; // description is on base schema
     schemas.push(obj);
     cacheProperty(property, `${key}Detail`, propertiesCache.defined);
-    schemas.push(makeDetailSchema(key));
+    schemas.push(makeDetailSchema(key, detailProperties, permissions));
   } else {
     obj.property = property;
     schemas.push(obj);

--- a/inputs/remove-all-of.js
+++ b/inputs/remove-all-of.js
@@ -1,0 +1,43 @@
+const SwaggerParser = require('swagger-parser'); // eslint-disable-line
+const { collapseAllOf } = require('./utils');
+
+const cloneApi = api => JSON.parse(JSON.stringify(api));
+
+const containsAllOf = obj =>
+  JSON.stringify(obj).indexOf('allOf') !== -1;
+
+const removeAllOfFrom = (obj) => {
+  if (obj && containsAllOf(obj)) {
+    Object
+      .keys(obj)
+      .forEach((key) => {
+        const prop = { [key]: obj[key] };
+        collapseAllOf(prop);
+        Object.assign(obj, prop);
+      });
+  }
+};
+
+const removeAllOf = async (apiObj) => {
+  const api = cloneApi(apiObj);
+  const dereferencedApi = await SwaggerParser.validate(cloneApi(api));
+
+  const { definitions } = api;
+  Object
+    .entries(definitions)
+    .filter(def => !def[0].endsWith('Basic') && !def[0].endsWith('Detail'))
+    .filter(def => containsAllOf(def[1]))
+    .forEach((def) => {
+      const name = def[0];
+      console.log(`remove allOf: ${name}`);
+      const definition = { [name]: dereferencedApi.definitions[name] };
+      collapseAllOf(definition);
+      removeAllOfFrom(definition[name].properties);
+      Object.assign(definitions, definition);
+    });
+  const items = collapseAllOf({ items: api.definitions.OBAccount2.properties.Account.items });
+  Object.assign(api.definitions.OBAccount2.properties.Account, items);
+  return api;
+};
+
+exports.removeAllOf = removeAllOf;


### PR DESCRIPTION
- Remove `allOf` use from active definitions 
- As swagger codegen tool does not handle `allOf` correctly.
- Add re-generated v2.0-rc3 swagger specifications.